### PR TITLE
Added RSA signing with digest none

### DIFF
--- a/Applet/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
+++ b/Applet/Applet/src/com/android/javacard/keymaster/KMKeymasterApplet.java
@@ -1043,8 +1043,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
           // Fill the scratch pad with zero
           Util.arrayFillNonAtomic(scratchPad,(short)0, (short)256, (byte)0);
           if(op.getPadding() == KMType.PADDING_NONE){
-              // Length cannot be greater then key size - we restrict this to 255 that ensures
-            // that it will never be greater then numerical value of the key also.
+              // Length cannot be greater then key size according to jcard sim
               if(len >= 256) KMException.throwIt(KMError.INVALID_INPUT_LENGTH);
  /*             // If Length is same as key size then
               // compare the data with key value - date should be less then key value.
@@ -1357,6 +1356,7 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
           // However as there is no padding we can treat signing as a RSA decryption operation.
           if(op.getDigest() == KMType.DIGEST_NONE && op.getPadding() == KMType.PADDING_NONE){
             if(op.getPurpose() == KMType.SIGN){
+              /*
             // Length cannot be greater then key size
             if(len > op.getKeySize()) KMException.throwIt(KMError.INVALID_INPUT_LENGTH);
             // If Length is same as key size then
@@ -1370,20 +1370,24 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
               if(tmpVariables[0] >= 0){
                 KMException.throwIt(KMError.INVALID_INPUT_LENGTH);
               }
-            }
+            }*/
             }else{//Verify
               if(len != 256) KMException.throwIt(KMError.INVALID_INPUT_LENGTH);
             }
-            // Fill the scratch pad with zero
+/*            // Fill the scratch pad with zero
             Util.arrayFillNonAtomic(scratchPad,(short)0, (short)256, (byte)0);
             // Everything is fine so copy input data to scratchpad.
             Util.arrayCopyNonAtomic(
               KMByteBlob.cast(data[INPUT_DATA]).getBuffer(),
               KMByteBlob.cast(data[INPUT_DATA]).getStartOff(),
               scratchPad, (short)(256 - len),len);
-            len = (short)256;
+            len = (short)256;*/
+            Util.arrayCopyNonAtomic(
+              KMByteBlob.cast(data[INPUT_DATA]).getBuffer(),
+              KMByteBlob.cast(data[INPUT_DATA]).getStartOff(),
+              scratchPad, (short)0,len);
           }else if (op.getDigest() == KMType.DIGEST_NONE && op.getPadding() == KMType.RSA_PKCS1_1_5_SIGN) {
-            // If PKCS1 padding and no digest - then 0x01||0x00||PS||0x00 on left such that PS >= 8 bytes
+    /*        // If PKCS1 padding and no digest - then 0x01||0x00||PS||0x00 on left such that PS >= 8 bytes
             // Data Length should be atleast 11 less then the key size - which is 256 bytes
             if(len > (short)(op.getKeySize() - 11)){
               KMException.throwIt(KMError.INVALID_INPUT_LENGTH);
@@ -1403,7 +1407,12 @@ public class KMKeymasterApplet extends Applet implements AppletEvent, ExtendedLe
               KMByteBlob.cast(data[INPUT_DATA]).getBuffer(),
               KMByteBlob.cast(data[INPUT_DATA]).getStartOff(),
               scratchPad, (short)(tmpVariables[0]+3),len);
-            len = op.getKeySize(); // this will be 256
+            len = op.getKeySize(); // this will be 256*/
+            Util.arrayCopyNonAtomic(
+              KMByteBlob.cast(data[INPUT_DATA]).getBuffer(),
+              KMByteBlob.cast(data[INPUT_DATA]).getStartOff(),
+              scratchPad, (short)0,len);
+
           }else if(op.getDigest()==KMType.SHA2_256 &&
             (op.getPadding() == KMType.RSA_PKCS1_1_5_SIGN ||op.getPadding() == KMType.RSA_PSS)){
             // Normal case with PKCS1 or PSS padding and with Digest SHA256

--- a/Applet/Applet/test/com/android/javacard/test/KMVTSTest.java
+++ b/Applet/Applet/test/com/android/javacard/test/KMVTSTest.java
@@ -1389,20 +1389,20 @@ public class KMVTSTest {
     cleanUp();
   }
 
-  /*
+
   // TODO Signing with no digest is not supported by crypto provider or javacard
   @Test
-  public void testSignVerifyWithRsaNoneNoPad(){
+  public void testSignWithRsaNoneNoPad(){
     init();
-    testSignVerifyWithRsa(KMType.DIGEST_NONE, KMType.RSA_PKCS1_1_5_SIGN);
+    testSignVerifyWithRsa(KMType.DIGEST_NONE, KMType.PADDING_NONE,false, false);
     cleanUp();
   }
   @Test
-  public void testSignVerifyWithRsaNonePkcs1(){
+  public void testSignWithRsaNonePkcs1(){
     init();
-    testSignVerifyWithRsa(KMType.DIGEST_NONE, KMType.RSA_PKCS1_1_5_SIGN);
+    testSignVerifyWithRsa(KMType.DIGEST_NONE, KMType.RSA_PKCS1_1_5_SIGN,false, false);
     cleanUp();
-  }*/
+  }
 
   @Test
   public void testSignVerifyWithHmacSHA256WithUpdate(){
@@ -1432,19 +1432,19 @@ public class KMVTSTest {
   @Test
   public void testSignVerifyWithRsaSHA256Pkcs1(){
     init();
-    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PKCS1_1_5_SIGN,false);
+    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PKCS1_1_5_SIGN,false, true);
     cleanUp();
   }
   @Test
   public void testSignVerifyWithRsaSHA256Pss(){
     init();
-    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PSS,false);
+    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PSS,false, true);
     cleanUp();
   }
   @Test
   public void testSignVerifyWithRsaSHA256Pkcs1WithUpdate(){
     init();
-    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PKCS1_1_5_SIGN,true);
+    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PKCS1_1_5_SIGN,true, true);
     cleanUp();
   }
 
@@ -1511,7 +1511,7 @@ public class KMVTSTest {
   @Test
   public void testSignVerifyWithRsaSHA256PssWithUpdate(){
     init();
-    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PSS,true);
+    testSignVerifyWithRsa(KMType.SHA2_256, KMType.RSA_PSS,true, true);
     cleanUp();
   }
   @Test
@@ -1617,7 +1617,7 @@ public class KMVTSTest {
     Assert.assertTrue(equal == 0);
   }
 
-  public void testSignVerifyWithRsa(byte digest, byte padding, boolean update){
+  public void testSignVerifyWithRsa(byte digest, byte padding, boolean update, boolean verifyFlag){
     short rsaKeyArr = generateRsaKey(null, null);
     short keyBlobPtr = KMArray.cast(rsaKeyArr).get((short)1);
     byte[] keyBlob= new byte[KMByteBlob.cast(keyBlobPtr).length()];
@@ -1638,6 +1638,10 @@ public class KMVTSTest {
     byte[] signatureData = new byte[KMByteBlob.cast(keyBlobPtr).length()];
     Util.arrayCopyNonAtomic(KMByteBlob.cast(keyBlobPtr).getBuffer(), KMByteBlob.cast(keyBlobPtr).getStartOff(),
       signatureData,(short)0, (short)signatureData.length);
+    if(verifyFlag == false) {
+      Assert.assertEquals(signatureData.length,256);
+      return;
+    }
     ret = processMessage(plainData,
       KMByteBlob.instance(keyBlob,(short)0, (short)keyBlob.length),
       KMType.VERIFY,


### PR DESCRIPTION
This uses RSA private key decryption with no padding from jcard sim to sign the data. The padding for pkcs1 and padding none is done before the jcard sim api is called.
However there is no way to verify the signature using jcard sim as the public key encryption without padding allows only 255 bytes of input data.